### PR TITLE
test: add toggle button tests for Preview/Code tabs

### DIFF
--- a/src/app/__tests__/main-content.test.tsx
+++ b/src/app/__tests__/main-content.test.tsx
@@ -1,0 +1,92 @@
+import { test, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { MainContent } from "@/app/main-content";
+
+// Mock context providers
+vi.mock("@/lib/contexts/file-system-context", () => ({
+  FileSystemProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("@/lib/contexts/chat-context", () => ({
+  ChatProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+// Mock child components
+vi.mock("@/components/chat/ChatInterface", () => ({
+  ChatInterface: () => <div data-testid="chat-interface">Chat</div>,
+}));
+
+vi.mock("@/components/editor/FileTree", () => ({
+  FileTree: () => <div data-testid="file-tree">FileTree</div>,
+}));
+
+vi.mock("@/components/editor/CodeEditor", () => ({
+  CodeEditor: () => <div data-testid="code-editor">CodeEditor</div>,
+}));
+
+vi.mock("@/components/preview/PreviewFrame", () => ({
+  PreviewFrame: () => <div data-testid="preview-frame">PreviewFrame</div>,
+}));
+
+vi.mock("@/components/HeaderActions", () => ({
+  HeaderActions: () => <div data-testid="header-actions">Actions</div>,
+}));
+
+// Mock resizable components
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizablePanel: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizableHandle: () => <div />,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+test("Preview tab is active by default and shows PreviewFrame", () => {
+  render(<MainContent />);
+
+  expect(screen.getByTestId("preview-frame")).toBeDefined();
+  expect(screen.queryByTestId("code-editor")).toBeNull();
+  expect(screen.queryByTestId("file-tree")).toBeNull();
+});
+
+test("clicking Code tab shows code editor and file tree", () => {
+  render(<MainContent />);
+
+  const codeTab = screen.getByRole("tab", { name: "Code" });
+  fireEvent.click(codeTab);
+
+  expect(screen.getByTestId("code-editor")).toBeDefined();
+  expect(screen.getByTestId("file-tree")).toBeDefined();
+  expect(screen.queryByTestId("preview-frame")).toBeNull();
+});
+
+test("clicking Preview tab after Code tab restores preview", () => {
+  render(<MainContent />);
+
+  // Switch to code view
+  fireEvent.click(screen.getByRole("tab", { name: "Code" }));
+  expect(screen.getByTestId("code-editor")).toBeDefined();
+
+  // Switch back to preview
+  fireEvent.click(screen.getByRole("tab", { name: "Preview" }));
+  expect(screen.getByTestId("preview-frame")).toBeDefined();
+  expect(screen.queryByTestId("code-editor")).toBeNull();
+});
+
+test("both Preview and Code tab buttons are always visible", () => {
+  render(<MainContent />);
+
+  expect(screen.getByRole("tab", { name: "Preview" })).toBeDefined();
+  expect(screen.getByRole("tab", { name: "Code" })).toBeDefined();
+});


### PR DESCRIPTION
Adds tests to verify the Preview/Code toggle buttons work correctly.

The toggle logic was reviewed and found to be correct - no bugs were found. This PR adds test coverage to prevent future regressions.

Closes #2

Generated with [Claude Code](https://claude.ai/code)